### PR TITLE
update: include workload partitioning annotation in cluster-proxy-service-proxy

### DIFF
--- a/pkg/controllers/agentmanifest.go
+++ b/pkg/controllers/agentmanifest.go
@@ -95,6 +95,9 @@ func newDeployment(agentInstallNamespace string,
 			Labels: map[string]string{
 				"app": "cluster-proxy-service-proxy",
 			},
+			Annotations: map[string]string{
+				"target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}",
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{


### PR DESCRIPTION
when cluster-proxy-service-proxy pod gets deployed to SNO, it should take make use of workload partitioning.
 
fixes: https://issues.redhat.com/browse/OCPBUGS-7652