### PR TITLE
Revert "update: include workload partitioning annotation in cluster-proxy-service-proxy"

### DIFF
--- a/pkg/controllers/agentmanifest.go
+++ b/pkg/controllers/agentmanifest.go
@@ -95,9 +95,6 @@ func newDeployment(agentInstallNamespace string,
 			Labels: map[string]string{
 				"app": "cluster-proxy-service-proxy",
 			},
-			Annotations: map[string]string{
-				"target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}",
-			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{


### PR DESCRIPTION
Reverts stolostron/cluster-proxy-addon#95

The annotation should be in pod (not in deployment)