### PR TITLE
Revert "when cluster-proxy-service-proxy pod gets deployed to SNO, it should take make use of workload partitioning."

### DIFF
--- a/pkg/controllers/agentmanifest.go
+++ b/pkg/controllers/agentmanifest.go
@@ -107,9 +107,6 @@ func newDeployment(agentInstallNamespace string,
 					Labels: map[string]string{
 						"app": "cluster-proxy-service-proxy",
 					},
-					Annotations: map[string]string{
-						"target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}",
-					},
 				},
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{


### PR DESCRIPTION
Reverts stolostron/cluster-proxy-addon#98
