### PR TITLE
Fix e2e fail.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ build-e2e:
 
 deploy-ocm:
 	curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | INSTALL_DIR=$(PWD) bash
-	$(PWD)/clusteradm init --output-join-command-file join.sh --wait
+	$(PWD)/clusteradm init --bundle-version="latest" --output-join-command-file join.sh --wait
 	echo " loopback --force-internal-endpoint-lookup" >> join.sh && sh join.sh
 	$(PWD)/clusteradm accept --clusters loopback --wait 30
 	$(KUBECTL) wait --for=condition=ManagedClusterConditionAvailable managedcluster/loopback


### PR DESCRIPTION
In upstream upgrade PR, https://github.com/open-cluster-management-io/cluster-proxy/pull/207, it upgrade to using latest image in clusteradm as well. 

But in downstream, we don' have this field updated.


@qiujian16  From the question in channel: https://kubernetes.slack.com/archives/C01GE7YSUUF/p1729251075877059. cluster-proxy-addon is not widely used in the community. 

So I want to propose to archive cluster-proxy in ocm-io step by step, and then merge cluster-proxy-addon and cluster-proxy repo in stolostron. This way, we can save our energy on diff management and e2e fails on this component.

--

Kudo to @haoqing0110 , help quickly debug the e2e failure.