### PR TITLE
Backport ANP upgrade to mce 2.3.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ IMAGE_TAG ?= latest
 
 # ANP source code
 ANP_NAME ?= apiserver-network-proxy
-ANP_VERSION ?= 0.1.1
+ANP_VERSION ?= 0.1.6.patch
 ANP_SRC_CODE ?= dependencymagnet/${ANP_NAME}/${ANP_VERSION}.tar.gz
 
 # Add packages to do unit test


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ACM-15765
