### PR TITLE
Change to pod internal conenction from agent to service-proxy.

### DIFF
--- a/pkg/controllers/certcontroller.go
+++ b/pkg/controllers/certcontroller.go
@@ -62,7 +62,7 @@ func registerCertController(certNamespace string,
 				Namespace: certNamespace,
 				Name:      constant.ServerCertSecretName,
 				Validity:  time.Hour * 24 * 180, // align with the signer ca by cluster-proxy
-				HostNames: []string{"*", "localhost", "127.0.0.1"},
+				HostNames: []string{"*", "localhost", "127.0.0.1", "*.proxy"},
 				Lister:    secertLister,
 				Client:    secertGetter,
 			},


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ACM-16801

`tls: failed to verify certificate: x509: certificate is valid for *, localhost, 127.0.0.1, not cluster-proxy-085552f3cfe64c5e2bac5d19b0033079e25ced90029637e5b`

The TLS certificate validation fails because the server's certificate SAN (Subject Alternative Name) doesn't match the requested hostname 'cluster-proxy-xxx', though it can be bypassed using InsecureSkipVerify on the client side.

Related:

https://github.com/stolostron/cluster-proxy-addon/blob/d8cdedcc7ea314018f88b9384853bbb3980c3483/pkg/controllers/certcontroller.go#L65

`*` used to match `cluster-proxy-085552f3cfe64c5e2bac5d19b0033079e25ced90029637e5b`.

Jira： https://issues.redhat.com/browse/ACM-16801

@haoqing0110 Provide the rca: https://github.com/golang/go/commit/375031d8dcec9ae74d2dbc437b201107dba3bb5f it's golang `verify` function changed.

Downstream upgrade builder image to: https://gitlab.cee.redhat.com/mce-cpaas-midstream/cluster-proxy-addon/-/blob/multicluster-engine-2.8-rhel-9/distgit/containers/cluster-proxy-addon/Dockerfile.in?ref_type=heads#L10

TODO: @xuezhaojun  This PR need to be backported to before releases.