### PR TITLE
Update cluster-proxy image to main backplane-2.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build
 
 HELM?=_output/linux-amd64/helm
 
-IMAGE_CLUSTER_PROXY?=quay.io/stolostron/cluster-proxy:latest
+IMAGE_CLUSTER_PROXY?=quay.io/stolostron/cluster-proxy:main
 IMAGE_PULL_POLICY=Always
 IMAGE_TAG?=latest
 


### PR DESCRIPTION
Update cluster-proxy image from latest to main for backplane-2.5