### PR TITLE
Upgrade ANP to fix cve issue https://www.cve.org/CVERecord?id=CVE-2025-22868.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ IMAGE_TAG ?= latest
 
 # ANP source code
 ANP_NAME ?= apiserver-network-proxy
-ANP_VERSION ?= 0.1.6.patch
+ANP_VERSION ?= 0.1.6.patch-02
 ANP_SRC_CODE ?= dependencymagnet/${ANP_NAME}/${ANP_VERSION}.tar.gz
 PERMANENT_TMP ?= _output
 


### PR DESCRIPTION
After fix:
```
➜  cluster-proxy-addon git:(fix-cve-22868) ✗ go version -m proxy-server | grep golang.org/x/oauth2
        dep     golang.org/x/oauth2     v0.28.0
➜  cluster-proxy-addon git:(fix-cve-22868) ✗ go version -m proxy-server | grep golang.org/x/crypto
➜  cluster-proxy-addon git:(fix-cve-22868) ✗ go version -m proxy-agent | grep golang.org/x/crypto
➜  cluster-proxy-addon git:(fix-cve-22868) ✗ go version -m proxy-agent | grep golang.org/x/oauth2
```


Related: https://issues.redhat.com/browse/ACM-19160