### PR TITLE
Update PipelineRun pathInRepo to use common_mce_2.6.yaml for backplane-2.6

### DIFF
--- a/.tekton/cluster-proxy-addon-mce-26-pull-request.yaml
+++ b/.tekton/cluster-proxy-addon-mce-26-pull-request.yaml
@@ -38,7 +38,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.6.yaml
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-26

--- a/.tekton/cluster-proxy-addon-mce-26-push.yaml
+++ b/.tekton/cluster-proxy-addon-mce-26-push.yaml
@@ -35,7 +35,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.6.yaml
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-26


### PR DESCRIPTION
## Summary

- Updated pathInRepo value in `.tekton/cluster-proxy-addon-mce-26-pull-request.yaml` from `pipelines/common.yaml` to `pipelines/common_mce_2.6.yaml`
- Updated pathInRepo value in `.tekton/cluster-proxy-addon-mce-26-push.yaml` from `pipelines/common.yaml` to `pipelines/common_mce_2.6.yaml`

This ensures the pipeline references match the branch version (backplane-2.6 -> common_mce_2.6.yaml) as per the standard naming convention.

## Test plan

- [x] Verified both PipelineRun files are updated with correct pathInRepo values
- [x] Ensured changes are specific to backplane-2.6 branch

🤖 Generated with [Claude Code](https://claude.ai/code)