### PR TITLE
Fix pathInRepo values to match backplane-2.7 branch version

### DIFF
--- a/.tekton/cluster-proxy-addon-mce-27-pull-request.yaml
+++ b/.tekton/cluster-proxy-addon-mce-27-pull-request.yaml
@@ -38,7 +38,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.7.yaml
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-27

--- a/.tekton/cluster-proxy-addon-mce-27-push.yaml
+++ b/.tekton/cluster-proxy-addon-mce-27-push.yaml
@@ -35,7 +35,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.7.yaml
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-27


### PR DESCRIPTION
## Summary

- Updated pathInRepo values in tekton pipeline files from `pipelines/common.yaml` to `pipelines/common_mce_2.7.yaml`
- Ensures pipeline references match the correct version-specific path for backplane-2.7 branch
- Affects both pull-request and push pipeline configurations

## Test plan

- [x] Verified pathInRepo values are correctly updated in both tekton pipeline files
- [ ] Test pipeline execution with updated pathInRepo references
- [ ] Validate pipeline runs successfully with version-specific pipeline configuration

🤖 Generated with [Claude Code](https://claude.ai/code)