### PR TITLE
Update pathInRepo to use correct branch version for backplane-2.8

### DIFF
--- a/.tekton/cluster-proxy-addon-mce-28-pull-request.yaml
+++ b/.tekton/cluster-proxy-addon-mce-28-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.8.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-28
   workspaces:

--- a/.tekton/cluster-proxy-addon-mce-28-push.yaml
+++ b/.tekton/cluster-proxy-addon-mce-28-push.yaml
@@ -38,7 +38,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.8.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-28
   workspaces:


### PR DESCRIPTION
## Summary

- Updated pathInRepo value in PipelineRun files from `pipelines/common.yaml` to `pipelines/common_mce_2.8.yaml`
- This ensures the correct pipeline is used for the backplane-2.8 branch

## Changes

- `.tekton/cluster-proxy-addon-mce-28-pull-request.yaml`: Updated pathInRepo value
- `.tekton/cluster-proxy-addon-mce-28-push.yaml`: Updated pathInRepo value

## Test plan

- [x] Verified pathInRepo values are correctly set to `pipelines/common_mce_2.8.yaml`
- [x] Confirmed changes match the branch version format requirement

🤖 Generated with [Claude Code](https://claude.ai/code)