### PR TITLE
Update tekton pipeline pathInRepo for backplane-2.9 branch

### DIFF
--- a/.tekton/cluster-proxy-addon-mce-29-pull-request.yaml
+++ b/.tekton/cluster-proxy-addon-mce-29-pull-request.yaml
@@ -44,7 +44,7 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/common.yaml
+      value: pipelines/common_mce_2.9.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-29
   workspaces:

--- a/.tekton/cluster-proxy-addon-mce-29-push.yaml
+++ b/.tekton/cluster-proxy-addon-mce-29-push.yaml
@@ -41,7 +41,7 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/common.yaml
+      value: pipelines/common_mce_2.9.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-29
   workspaces:


### PR DESCRIPTION
## Summary
- Updated pathInRepo value from `pipelines/common.yaml` to `pipelines/common_mce_2.9.yaml` in tekton PipelineRun files
- This ensures the pipeline references the correct version-specific pipeline catalog for backplane-2.9 branch

## Files Changed
- `.tekton/cluster-proxy-addon-mce-29-pull-request.yaml`
- `.tekton/cluster-proxy-addon-mce-29-push.yaml`

## Test Plan
- Verify tekton pipeline runs correctly with updated pathInRepo reference
- Confirm pipeline catalog exists at `pipelines/common_mce_2.9.yaml` in konflux-build-catalog repo

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>