### PR TITLE
Fix pathInRepo to use branch-specific pipeline file for backplane-2.10

### DIFF
--- a/.tekton/cluster-proxy-addon-mce-210-pull-request.yaml
+++ b/.tekton/cluster-proxy-addon-mce-210-pull-request.yaml
@@ -45,7 +45,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.10.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-210
   workspaces:


### PR DESCRIPTION
## Summary
- Updated pathInRepo from `pipelines/common.yaml` to `pipelines/common_mce_2.10.yaml` in pull request pipeline
- Ensures consistency with push pipeline and matches backplane-2.10 branch version

## Test plan
- [x] Verified push pipeline already uses correct path
- [x] Updated pull request pipeline to match
- [ ] CI pipeline validation

🤖 Generated with [Claude Code](https://claude.ai/code)