### PR TITLE
Fix pathInRepo value in Tekton pipeline for main branch

### DIFF
--- a/.tekton/cluster-proxy-addon-mce-210-pull-request.yaml
+++ b/.tekton/cluster-proxy-addon-mce-210-pull-request.yaml
@@ -45,7 +45,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common_mce_2.10.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-210
   workspaces:


### PR DESCRIPTION
## Summary

- Fixed pathInRepo value in `.tekton/cluster-proxy-addon-mce-210-pull-request.yaml`
- Changed from `pipelines/common.yaml` to `pipelines/common_mce_2.10.yaml`
- Aligns with requirement that main branch should use `pipelines/common_mce_2.10.yaml`

## Changes

- Updated `.tekton/cluster-proxy-addon-mce-210-pull-request.yaml` line 48
- The push pipeline was already correct with `pipelines/common_mce_2.10.yaml`

## Testing

- [ ] Verify pipeline configuration is consistent across pull-request and push workflows
- [ ] Confirm pathInRepo points to correct MCE 2.10 pipeline

Fixes the pipeline configuration to match branch version requirements.