### PR TITLE
Add missing build platforms and Slack notification params to Tekton pipelines for 2.6

### DIFF
--- a/.tekton/cluster-proxy-addon-mce-26-pull-request.yaml
+++ b/.tekton/cluster-proxy-addon-mce-26-pull-request.yaml
@@ -30,6 +30,12 @@ spec:
     value: Dockerfile.rhtap
   - name: path-context
     value: .
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/cluster-proxy-addon-mce-26-push.yaml
+++ b/.tekton/cluster-proxy-addon-mce-26-push.yaml
@@ -27,6 +27,18 @@ spec:
     value: Dockerfile.rhtap
   - name: path-context
     value: .
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
+  - name: send-slack-notification
+    value: "true"
+  - name: konflux-application-name
+    value: "release-mce-26"
+  - name: slack-member-id
+    value: "U01TX25RJ3B"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary

- Added missing `build-platforms` parameter with multi-architecture support (linux/x86_64, linux/arm64, linux/ppc64le, linux/s390x) to both push and pull-request pipelines
- Added Slack notification parameters to push pipeline:
  - `send-slack-notification: "true"`
  - `konflux-application-name: "release-mce-26"`
  - `slack-member-id: "U01TX25RJ3B"`

## Motivation

This update ensures that the Tekton pipelines for the cluster-proxy-addon in the backplane-2.6 branch have the necessary parameters for:
1. Multi-architecture builds across all supported platforms
2. Proper Slack notifications for CI/CD pipeline events
3. Consistent configuration with project standards

## Test Plan

- [x] Verified YAML syntax is valid
- [x] Confirmed parameter names and values match specification
- [x] Ensured branch-specific application name (release-mce-26) corresponds to backplane-2.6
- [ ] Pipeline validation will be performed by CI

## Files Modified

- `.tekton/cluster-proxy-addon-mce-26-push.yaml`: Added build-platforms and Slack notification parameters
- `.tekton/cluster-proxy-addon-mce-26-pull-request.yaml`: Added build-platforms parameter