### PR TITLE
Add missing pipeline parameters for multi-platform builds and Slack notifications

### DIFF
--- a/.tekton/cluster-proxy-addon-mce-27-pull-request.yaml
+++ b/.tekton/cluster-proxy-addon-mce-27-pull-request.yaml
@@ -30,6 +30,12 @@ spec:
     value: Dockerfile.rhtap
   - name: path-context
     value: .
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/cluster-proxy-addon-mce-27-push.yaml
+++ b/.tekton/cluster-proxy-addon-mce-27-push.yaml
@@ -27,6 +27,18 @@ spec:
     value: Dockerfile.rhtap
   - name: path-context
     value: .
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
+  - name: send-slack-notification
+    value: "true"
+  - name: konflux-application-name
+    value: "release-mce-27"
+  - name: slack-member-id
+    value: "U01TX25RJ3B"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary

Added missing required pipeline parameters to both push and pull-request Tekton pipeline files:

### Changes Made

**For `*-push.yaml` files:**
- Added `build-platforms` parameter with support for linux/x86_64, linux/arm64, linux/ppc64le, linux/s390x
- Added `send-slack-notification` parameter set to "true"
- Added `konflux-application-name` parameter set to "release-mce-27" (corresponding to backplane-2.7 branch)
- Added `slack-member-id` parameter set to "U01TX25RJ3B"

**For `*-pull-request.yaml` files:**
- Added `build-platforms` parameter with support for linux/x86_64, linux/arm64, linux/ppc64le, linux/s390x

### Files Modified
- `.tekton/cluster-proxy-addon-mce-27-push.yaml`
- `.tekton/cluster-proxy-addon-mce-27-pull-request.yaml`

These parameters enable multi-platform builds and proper Slack notifications for the CI/CD pipeline.

## Test Plan

- [ ] Verify pipeline configurations are syntactically correct
- [ ] Test push pipeline triggers with new parameters
- [ ] Test pull request pipeline triggers with new parameters
- [ ] Confirm Slack notifications are working as expected