### PR TITLE
Add missing Tekton pipeline parameters for backplane-2.9

### DIFF
--- a/.tekton/cluster-proxy-addon-mce-29-push.yaml
+++ b/.tekton/cluster-proxy-addon-mce-29-push.yaml
@@ -33,6 +33,12 @@ spec:
     value: Dockerfile.rhtap
   - name: path-context
     value: .
+  - name: send-slack-notification
+    value: "true"
+  - name: konflux-application-name
+    value: "release-mce-29"
+  - name: slack-member-id
+    value: "U01TX25RJ3B"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary

This PR adds missing required parameters to the Tekton push pipeline for the backplane-2.9 branch:

- `send-slack-notification: "true"` - Enables Slack notifications for pipeline runs
- `konflux-application-name: "release-mce-29"` - Sets the application name for the 2.9 release
- `slack-member-id: "U01TX25RJ3B"` - Specifies the Slack member ID for notifications

## Analysis

- **Push pipeline**: Added 3 missing parameters (build-platforms was already present)
- **Pull-request pipeline**: No changes needed (build-platforms already present)

## Testing

- [x] Verified existing `build-platforms` parameter is correctly configured
- [x] Added all required notification and application parameters
- [x] Followed the expected format for backplane-2.9 (release-mce-29)