### PR TITLE
Update Dockerfile.rhtap builder to rhel_8_1.23

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.23 AS builder
 
 WORKDIR /go/src/github.com/stolostron/cluster-proxy-addon
 


### PR DESCRIPTION
## Summary

Update the builder image in Dockerfile.rhtap from `rhel_9_1.22` to `rhel_8_1.23` to ensure consistency with the required builder version.

## Changes
- Updated the FROM instruction in Dockerfile.rhtap to use `rhel_8_1.23` instead of `rhel_9_1.22`

## Testing
- No functional changes, only builder image version update
- Build verification should be performed to ensure compatibility