### PR TITLE
Update dockerfile.rhtap builder to rhel_8_1.23

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.23 AS builder
 
 WORKDIR /go/src/github.com/stolostron/cluster-proxy-addon
 


### PR DESCRIPTION
## Summary
Update Dockerfile.rhtap builder image from `rhel_9_1.22` to `rhel_8_1.23` to ensure consistency with project requirements.

## Changes
- Updated FROM instruction in Dockerfile.rhtap from `brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22` to `brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.23`

## Test plan
- [ ] Verify the new builder image is available and accessible
- [ ] Run build process to ensure no compatibility issues
- [ ] Check that all existing functionality works with the updated builder

🤖 Generated with [Claude Code](https://claude.ai/code)