### PR TITLE
Increase gRPC keepalive timeout from 5 seconds to 10 minutes

### DIFF
--- a/pkg/userserver/user_server.go
+++ b/pkg/userserver/user_server.go
@@ -128,7 +128,7 @@ func (k *userServer) init(ctx context.Context) error {
 			net.JoinHostPort(k.proxyServerHost, strconv.Itoa(k.proxyServerPort)),
 			grpc.WithTransportCredentials(grpccredentials.NewTLS(proxyTLSCfg)),
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{
-				Time: time.Second * 5,
+				Time: time.Minute * 10,
 			}),
 		)
 		if err != nil {


### PR DESCRIPTION
## Summary

- Updated gRPC keepalive timeout in user_server.go from 5 seconds to 10 minutes
- This change increases connection stability for long-running gRPC connections

## Changes

- Modified `pkg/userserver/user_server.go` line 131
- Changed `Time: time.Second * 5` to `Time: time.Minute * 10` in the keepalive.ClientParameters

## Test Plan

- [ ] Verify gRPC connections maintain keepalive for 10 minutes
- [ ] Test connection stability under various network conditions
- [ ] Ensure no breaking changes in existing functionality