### PR TITLE
Update gRPC keepalive timeout from 5 seconds to 10 minutes

### DIFF
--- a/pkg/userserver/user_server.go
+++ b/pkg/userserver/user_server.go
@@ -135,7 +135,7 @@ func (k *userServer) init(ctx context.Context) error {
 			net.JoinHostPort(k.proxyServerHost, strconv.Itoa(k.proxyServerPort)),
 			grpc.WithTransportCredentials(grpccredentials.NewTLS(proxyTLSCfg)),
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{
-				Time: time.Second * 5,
+				Time: time.Minute * 10,
 			}),
 		)
 		if err != nil {


### PR DESCRIPTION
## Summary

This PR updates the gRPC keepalive timeout in the user server from 5 seconds to 10 minutes to improve connection stability for long-running requests.

## Changes

- Modified `pkg/userserver/user_server.go` to change the keepalive `Time` parameter from `time.Second * 5` to `time.Minute * 10`
- This affects the gRPC tunnel configuration used for proxy connections

## Rationale

The current 5-second keepalive timeout is quite aggressive and may cause unnecessary network overhead. A 10-minute timeout provides better balance between connection health monitoring and resource efficiency, especially for long-running operations.

## Testing

- [ ] Verify gRPC connections remain stable under normal load
- [ ] Test long-running proxy operations
- [ ] Monitor connection resource usage

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>