### PR TITLE
Update gRPC keepalive timeout from 5 seconds to 10 minutes

### DIFF
--- a/pkg/userserver/user_server.go
+++ b/pkg/userserver/user_server.go
@@ -135,7 +135,7 @@ func (k *userServer) init(ctx context.Context) error {
 			net.JoinHostPort(k.proxyServerHost, strconv.Itoa(k.proxyServerPort)),
 			grpc.WithTransportCredentials(grpccredentials.NewTLS(proxyTLSCfg)),
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{
-				Time: time.Second * 5,
+				Time: time.Minute * 10,
 			}),
 		)
 		if err != nil {


### PR DESCRIPTION
## Summary

- Updated gRPC keepalive timeout in `pkg/userserver/user_server.go` from `time.Second * 5` to `time.Minute * 10`
- This change improves connection stability by increasing the keepalive timeout for gRPC connections to the ANP proxy server

## Test plan

- [ ] Verify that the application builds successfully
- [ ] Test that gRPC connections maintain proper keepalive behavior with the new timeout
- [ ] Ensure no regression in proxy functionality

🤖 Generated with [Claude Code](https://claude.ai/code)