### PR TITLE
Increase gRPC keepalive time from 5 seconds to 10 minutes

### DIFF
--- a/pkg/userserver/user_server.go
+++ b/pkg/userserver/user_server.go
@@ -135,7 +135,7 @@ func (k *userServer) init(ctx context.Context) error {
 			net.JoinHostPort(k.proxyServerHost, strconv.Itoa(k.proxyServerPort)),
 			grpc.WithTransportCredentials(grpccredentials.NewTLS(proxyTLSCfg)),
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{
-				Time: time.Second * 5,
+				Time: time.Minute * 10,
 			}),
 		)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Extended gRPC keepalive timeout from 5 seconds to 10 minutes in user server
- Improves connection stability for long-running proxy connections
- Changes the Time parameter in grpc.WithKeepaliveParams from time.Second * 5 to time.Minute * 10

## Test plan
- [ ] Verify user server starts successfully with new keepalive configuration
- [ ] Test that proxy connections remain stable over longer periods
- [ ] Ensure no regression in connection handling

🤖 Generated with [Claude Code](https://claude.ai/code)