### PR TITLE
Increase gRPC keepalive timeout from 5s to 10m

### DIFF
--- a/pkg/userserver/user_server.go
+++ b/pkg/userserver/user_server.go
@@ -135,7 +135,7 @@ func (k *userServer) init(ctx context.Context) error {
 			net.JoinHostPort(k.proxyServerHost, strconv.Itoa(k.proxyServerPort)),
 			grpc.WithTransportCredentials(grpccredentials.NewTLS(proxyTLSCfg)),
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{
-				Time: time.Second * 5,
+				Time: time.Minute * 10,
 			}),
 		)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Increase keepalive timeout from 5 seconds to 10 minutes in user server gRPC tunnel configuration
- This change provides more stable connections for long-running proxy tunnels

## Test plan
- [x] Verify the change compiles successfully
- [x] Test proxy connections remain stable for extended periods
- [x] Confirm no regression in connection establishment

🤖 Generated with [Claude Code](https://claude.ai/code)