### PR TITLE
Add TRIGGER_BUILD file for CI trigger without code changes

### DIFF
--- a/TRIGGER_BUILD
+++ b/TRIGGER_BUILD
@@ -1,0 +1,5 @@
+# Build Trigger File
+# This file is used to trigger CI builds without making code changes.
+# Update the timestamp below to trigger a new build.
+
+LAST_TRIGGER_TIME=2025-08-26T10:30:00Z


### PR DESCRIPTION
## Summary
- Add a new `TRIGGER_BUILD` file that contains a timestamp for triggering CI builds without code changes
- This file can be updated to re-trigger CI pipelines and builds when needed
- Useful for testing CI infrastructure or re-running builds without actual code modifications

## Test plan
- [x] Verify the file is properly added to the repository
- [x] Update the timestamp in the file to test CI triggering functionality
- [x] Confirm CI builds are triggered when the file is modified

🤖 Generated with [Claude Code](https://claude.ai/code)