### PR TITLE
Add TRIGGER_BUILD file for backplane-2.7 CI trigger

### DIFF
--- a/TRIGGER_BUILD
+++ b/TRIGGER_BUILD
@@ -1,0 +1,6 @@
+# Build Trigger File
+# This file is used to trigger CI builds without making code changes.
+# Update the timestamp below to trigger a new build.
+# Target: backplane-2.7
+
+LAST_TRIGGER_TIME=2025-08-27T01:18:16Z


### PR DESCRIPTION
## Summary
- Add TRIGGER_BUILD file to backplane-2.7 branch for CI triggering
- Enables triggering CI builds without code changes for backplane-2.7
- Contains timestamp that can be updated to trigger new builds

## Test plan
- [x] Create TRIGGER_BUILD file with initial timestamp
- [ ] Verify CI builds are triggered when file is updated
- [ ] Test backplane-2.7 specific build pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)