### PR TITLE
Update TRIGGER_BUILD timestamp for backplane-2.7

### DIFF
--- a/TRIGGER_BUILD
+++ b/TRIGGER_BUILD
@@ -3,4 +3,4 @@
 # Update the timestamp below to trigger a new build.
 # Target: backplane-2.7
 
-LAST_TRIGGER_TIME=2025-08-27T01:18:16Z
+LAST_TRIGGER_TIME=2025-08-27T04:01:24Z


### PR DESCRIPTION
## Summary
Update the TRIGGER_BUILD file timestamp to trigger CI builds without code changes.

## Changes
- Updated `LAST_TRIGGER_TIME` from `2025-08-27T01:18:16Z` to `2025-08-27T04:01:24Z`

## Purpose
This change triggers the CI pipeline for the backplane-2.7 branch without requiring any code modifications, useful for rebuilding or testing purposes.

## Testing
- [x] File updated with current timestamp
- [x] Commit signed as per project requirements