### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cluster-proxy-addon-mce-29

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -10,7 +10,8 @@ RUN make build-anp
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
-    name="cluster-proxy-addon" \
+    name="multicluster-engine/cluster-proxy-addon-rhel9" \
+    cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
     com.redhat.component="cluster-proxy-addon" \
     description="Cluster Proxy Addon allows users to access the managed clusters from a hub cluster" \
     io.k8s.description="Cluster Proxy Addon allows users to access the managed clusters from a hub cluster" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
