### PR TITLE
Add repository url label to container images

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -10,6 +10,7 @@ RUN make build-anp
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
+      url="https://github.com/stolostron/cluster-proxy-addon" \
     name="cluster-proxy-addon" \
     com.redhat.component="cluster-proxy-addon" \
     description="Cluster Proxy Addon allows users to access the managed clusters from a hub cluster" \


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** backplane-2.10

**Components affected:** cluster-proxy-addon

**Branch details:** cluster-proxy-addon (branch: backplane-2.10)

**Label added:**
- url: https://github.com/stolostron/cluster-proxy-addon

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.