### PR TITLE
fix: add explicit replace directives for CVE-2024-24786

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,3 +84,8 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace (
+	github.com/golang/protobuf => github.com/golang/protobuf v1.5.4
+	google.golang.org/protobuf => google.golang.org/protobuf v1.33.0
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -48,7 +48,7 @@ github.com/gogo/protobuf/sortkeys
 # github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 ## explicit
 github.com/golang/groupcache/lru
-# github.com/golang/protobuf v1.5.4
+# github.com/golang/protobuf v1.5.4 => github.com/golang/protobuf v1.5.4
 ## explicit; go 1.17
 github.com/golang/protobuf/proto
 github.com/golang/protobuf/ptypes
@@ -302,7 +302,7 @@ google.golang.org/grpc/serviceconfig
 google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
-# google.golang.org/protobuf v1.33.0
+# google.golang.org/protobuf v1.33.0 => google.golang.org/protobuf v1.33.0
 ## explicit; go 1.17
 google.golang.org/protobuf/encoding/protojson
 google.golang.org/protobuf/encoding/prototext
@@ -894,3 +894,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
+# github.com/golang/protobuf => github.com/golang/protobuf v1.5.4
+# google.golang.org/protobuf => google.golang.org/protobuf v1.33.0


### PR DESCRIPTION
## Summary

This PR adds explicit `replace` directives in `go.mod` to force protobuf packages to safe versions, addressing CVE-2024-24786.

## Problem Analysis

### CVE-2024-24786 Overview

CVE-2024-24786 is a security vulnerability in Google's Protocol Buffers Go implementation that affects the `protojson.Unmarshal` function. When processing certain malformed JSON input, this function can enter an infinite loop, leading to a Denial of Service (DoS) attack.

- **CVSS Score**: 7.5 (High)
- **Affected versions**: All versions of `google.golang.org/protobuf` below v1.33.0
- **Fixed in**: v1.33.0 and above

### Why Security Scanners Report This Issue

Many security scanning tools (such as Trivy, Snyk, Dependabot, etc.) analyze Go projects by examining the output of `go mod graph`. When they detect that the dependency graph contains versions below v1.33.0, they report CVE-2024-24786 as a vulnerability.

**Dependency graph analysis shows these packages declaring older versions:**

```
github.com/google/gnostic-models@v0.6.8 -> google.golang.org/protobuf@v1.27.1
github.com/onsi/ginkgo/v2@v2.17.1 -> google.golang.org/protobuf@v1.28.0
k8s.io/kube-openapi@v0.0.0-20240228011516-70dd3763d340 -> google.golang.org/protobuf@v1.27.1
sigs.k8s.io/apiserver-network-proxy@v0.0.27 -> google.golang.org/protobuf@v1.26.0-rc.1
```

### The Reality: No Actual Vulnerability

**However, the project is NOT actually vulnerable.** Here's why:

Go's module system uses **MVS (Minimal Version Selection)** algorithm:
- When multiple dependencies require different versions of the same package
- Go automatically selects the **highest version** among all requirements
- In this project, that highest version is already **v1.33.0** (the safe version)

**Verification:**
```bash
$ go list -m google.golang.org/protobuf
google.golang.org/protobuf v1.33.0

$ grep "^# google.golang.org/protobuf" vendor/modules.txt
# google.golang.org/protobuf v1.33.0
```

### Why Add the `replace` Directive?

Although technically unnecessary (the project already uses v1.33.0), adding the `replace` directive provides several benefits:

1. **Silences False Positives**: Security scanners will recognize the explicit `replace` directive and stop reporting false positives
2. **Explicit Documentation**: Makes it clear to all developers and tools that we are intentionally using the safe version
3. **Future-Proofing**: Ensures that any future dependency additions will also use the safe version
4. **Compliance**: Satisfies security compliance requirements that may not understand Go's MVS mechanism

## Changes

- Added `replace` directive for `google.golang.org/protobuf v1.33.0` to fix CVE-2024-24786
- Added `replace` directive for `github.com/golang/protobuf v1.5.4` to ensure compatibility
  - Note: `google.golang.org/protobuf v1.33.0` requires `github.com/golang/protobuf v1.5.4` for compatibility
  - See https://github.com/golang/protobuf/issues/1596 for details
- Updated `vendor/modules.txt` to reflect the replace directives

## Testing

Verified that the project uses the correct versions:
```bash
$ go list -m -mod=readonly all | grep -E "google.golang.org/protobuf|github.com/golang/protobuf"
github.com/golang/protobuf v1.5.4 => github.com/golang/protobuf v1.5.4
google.golang.org/protobuf v1.33.0 => google.golang.org/protobuf v1.33.0
```

## References

- Similar fix in cluster-proxy: https://github.com/stolostron/cluster-proxy/pull/450
- CVE-2024-24786 announcement: https://groups.google.com/g/golang-announce/c/ArQ6CDgtEjY
- Compatibility issue: https://github.com/golang/protobuf/issues/1596

🤖 Generated with [Claude Code](https://claude.com/claude-code)