### PR TITLE
Revert "Update gRPC keepalive timeout from 5 seconds to 10 minutes"

### DIFF
--- a/pkg/userserver/user_server.go
+++ b/pkg/userserver/user_server.go
@@ -135,7 +135,7 @@ func (k *userServer) init(ctx context.Context) error {
 			net.JoinHostPort(k.proxyServerHost, strconv.Itoa(k.proxyServerPort)),
 			grpc.WithTransportCredentials(grpccredentials.NewTLS(proxyTLSCfg)),
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{
-				Time: time.Minute * 10,
+				Time: time.Second * 5,
 			}),
 		)
 		if err != nil {


### PR DESCRIPTION
Reverts stolostron/cluster-proxy-addon#514

Revert to release FedRAMP fixes first.