### PR TITLE
docs: add MCE version requirement to service-proxy README

### DIFF
--- a/pkg/serviceproxy/readme.md
+++ b/pkg/serviceproxy/readme.md
@@ -1,3 +1,7 @@
+## Requirements
+
+> **Note:** MCE (Multicluster Engine) version must be >= 2.9 to use the service-proxy feature.
+
 ### 1 The Pre-req of using service-proxy impersonation feature
 
 Both hub and managed cluster need to be configured with the same external IDP.


### PR DESCRIPTION
## Summary
- Added MCE version requirement (>= 2.9) at the beginning of the service-proxy README
- This provides clear documentation for users about minimum version requirements

## Motivation
Users need to know the minimum MCE version required to use the service-proxy feature before attempting to configure it.

## Test plan
- [x] Review documentation changes
- [x] Verify markdown formatting renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)