### PR TITLE
Update renovate.json branch pattern to match backplane-2.10+ branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "baseBranchPatterns": [
         "main",
-        "/^backplane-2\\.[4-9]$/"
+        "/^backplane-2\\.\\d+$/"
     ],
     "packageRules": [
         {
@@ -14,7 +14,7 @@
         {
             "matchBaseBranches": [
                 "main",
-                "/^backplane-2\\.[4-9]$/"
+                "/^backplane-2\\.\\d+$/"
             ],
             "matchManagers": [
                 "tekton"


### PR DESCRIPTION
## Summary

Update the `baseBranchPatterns` and `matchBaseBranches` patterns in renovate.json to support double-digit minor versions.

## Changes

- Changed pattern from `/^backplane-2\.[4-9]$/` to `/^backplane-2\.\d+$/`
- This pattern now matches:
  - Previous versions: backplane-2.4 through backplane-2.9
  - New versions: backplane-2.10, backplane-2.11
  - Future versions: backplane-2.12, backplane-2.13, etc.

## Motivation

The old pattern `/^backplane-2\.[4-9]$/` only matched single-digit minor versions (4-9). With the introduction of backplane-2.10 and backplane-2.11 branches, the pattern needed to be updated to `\d+` to match one or more digits.

## Testing

The regex pattern `/^backplane-2\.\d+$/` correctly matches:
- ✅ backplane-2.4
- ✅ backplane-2.9
- ✅ backplane-2.10
- ✅ backplane-2.11
- ✅ backplane-2.99 (future-proof)

Signed-off-by: xuezhaojun <zxue@redhat.com>