### PR TITLE
Update renovate.json branch pattern to support backplane-2.10+

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "baseBranchPatterns": [
         "main",
-        "/^backplane-2\\.[4-9]$/"
+        "/^backplane-2\\.\\d+$/"
     ],
     "packageRules": [
         {
@@ -14,7 +14,7 @@
         {
             "matchBaseBranches": [
                 "main",
-                "/^backplane-2\\.[4-9]$/"
+                "/^backplane-2\\.\\d+$/"
             ],
             "matchManagers": [
                 "tekton"


### PR DESCRIPTION
## Summary

Updates the `baseBranchPatterns` and `matchBaseBranches` patterns in renovate.json to support double-digit backplane branch versions.

## Changes

- Changed branch pattern from `/^backplane-2\.[4-9]$/` to `/^backplane-2\.\d+$/`
- Updated in both `baseBranchPatterns` (line 5) and `matchBaseBranches` (line 17)

## Motivation

The old pattern `/^backplane-2\.[4-9]$/` only matches single-digit minor versions (2.4 through 2.9). With the introduction of backplane-2.10 and backplane-2.11 branches, the pattern needs to match any number of digits after the dot.

The new pattern `/^backplane-2\.\d+$/` matches:
- backplane-2.4, backplane-2.5, ... backplane-2.9 (existing)
- backplane-2.10, backplane-2.11 (new)
- Any future backplane-2.X branches

## Testing

The regex pattern has been validated to match the current branch naming convention in the repository.

Signed-off-by: xuezhaojun