### PR TITLE
Disable Dockerfile updates in Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,9 @@
   "gomod": {
     "enabled": false
   },
+  "dockerfile": {
+    "enabled": false
+  },
   "timezone": "Asia/Shanghai",
   "schedule": ["on monday"]
 }


### PR DESCRIPTION
## Summary
This PR updates the `renovate.json` configuration to disable automatic Dockerfile updates by adding `"dockerfile": {"enabled": false}"`.

## Motivation
Disabling Dockerfile updates in Renovate helps maintain manual control over container image updates, ensuring they are reviewed and tested appropriately before being applied.

## Changes
- Added `"dockerfile": {"enabled": false}` to `renovate.json` to disable automatic Dockerfile dependency updates

## Testing
- Configuration follows the Renovate schema
- Maintains existing settings for gomod, labels, timezone, and schedule