### PR TITLE
Add temporary approvers for Konflux migration

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,6 +4,9 @@ reviewers:
 - qiujian16
 
 approvers:
-- xuezhaojun
 - skeeey
 - qiujian16
+# Temporary approvers added for Konflux migration to facilitate updates to release repo prow configuration
+# These will be removed after the migration is complete
+- xuezhaojun
+- zhujian7


### PR DESCRIPTION
## Summary

This PR adds two temporary approvers to the OWNERS file to facilitate the Konflux migration process:
- xuezhaojun
- zhujian7

## Reason

These approvers are temporarily added to streamline the prow configuration updates in the release repository during the Konflux migration process. They will be removed once the migration is complete.

## Changes

- Updated `OWNERS` file to add xuezhaojun and zhujian7 at the end of the approvers list
- Added comments explaining the temporary nature of these additions