### PR TITLE
Add deprecation notice for MCE 2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Cluster Proxy Addon
 
+> **⚠️ Deprecation Notice**
+>
+> Starting from **MCE 2.11**, this repository has been deprecated. All functionality has been integrated into the [cluster-proxy](https://github.com/stolostron/cluster-proxy) repository.
+>
+> This repository only serves **MCE 2.10 and earlier versions**. For MCE 2.11 and later, please refer to [cluster-proxy](https://github.com/stolostron/cluster-proxy).
+
 `cluster-proxy-addon` uses a reverse proxy server (ANP) to send requests from the hub to managed clusters.
 It also contains end-to-end tests for the overall cluster-proxy-addon functionality.
 


### PR DESCRIPTION
## Summary
- Add deprecation notice to README indicating this repository is deprecated starting from MCE 2.11
- All functionality has been integrated into the [cluster-proxy](https://github.com/stolostron/cluster-proxy) repository
- This repo now only serves MCE 2.10 and earlier versions

## Test plan
- [ ] Verify README renders correctly with the deprecation notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)