### PR TITLE
Update Dockerfile.rhtap labels for RHEL9 compliance

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -10,7 +10,8 @@ RUN make build-anp
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
-    name="cluster-proxy-addon" \
+    name="multicluster-engine/cluster-proxy-addon-rhel9" \
+    cpe="cpe:/a:redhat:multicluster_engine:2.8::el9" \
     com.redhat.component="cluster-proxy-addon" \
     description="Cluster Proxy Addon allows users to access the managed clusters from a hub cluster" \
     io.k8s.description="Cluster Proxy Addon allows users to access the managed clusters from a hub cluster" \


### PR DESCRIPTION
## Summary
- Update the `name` label to use the full component name `multicluster-engine/cluster-proxy-addon-rhel9`
- Add the `cpe` label with value `cpe:/a:redhat:multicluster_engine:2.8::el9` for CPE compliance tracking

## Motivation
These labels are required for proper RHEL9 container compliance and identification in the Red Hat ecosystem.

## Test plan
- [ ] Verify Dockerfile.rhtap syntax is valid
- [ ] Verify labels are correctly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)