### PR TITLE
Update Dockerfile.rhtap labels for RHTAP compliance

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -9,13 +9,14 @@ RUN make build-all
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
-    name="cluster-proxy-addon" \
+    name="multicluster-engine/cluster-proxy-addon-rhel9" \
     com.redhat.component="cluster-proxy-addon" \
     description="Cluster Proxy Addon allows users to access the managed clusters from a hub cluster" \
     io.k8s.description="Cluster Proxy Addon allows users to access the managed clusters from a hub cluster" \
     summary="A hub cluster proxy addon" \
     io.k8s.display-name="Red Hat Advanced Cluster Management Cluster Proxy Addon" \
-    io.openshift.tags="mce acm cluster-proxy-addon"
+    io.openshift.tags="mce acm cluster-proxy-addon" \
+    cpe="cpe:/a:redhat:multicluster_engine:2.6::el9"
 
 ENV USER_UID=10001
 


### PR DESCRIPTION
## Summary
- Update `name` label to `multicluster-engine/cluster-proxy-addon-rhel9` to match the component naming convention
- Add `cpe` label with value `cpe:/a:redhat:multicluster_engine:2.6::el9` for security scanning and compliance

## Test plan
- [ ] Verify the Dockerfile.rhtap can still be built successfully
- [ ] Confirm the image labels are correctly applied using `podman inspect` or `docker inspect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)