### PR TITLE
Update Dockerfile.rhtap labels for RHTAP compliance

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -10,8 +10,9 @@ RUN make build-anp
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
-    name="cluster-proxy-addon" \
+    name="multicluster-engine/cluster-proxy-addon-rhel9" \
     com.redhat.component="cluster-proxy-addon" \
+    cpe="cpe:/a:redhat:multicluster_engine:2.7::el9" \
     description="Cluster Proxy Addon allows users to access the managed clusters from a hub cluster" \
     io.k8s.description="Cluster Proxy Addon allows users to access the managed clusters from a hub cluster" \
     summary="A hub cluster proxy addon" \


### PR DESCRIPTION
## Summary

- Update the `name` label to use the component name format: `multicluster-engine/cluster-proxy-addon-rhel9`
- Add the `cpe` label for Red Hat product identification: `cpe:/a:redhat:multicluster_engine:2.7::el9`

These changes ensure the container image labels comply with RHTAP (Red Hat Trusted Application Pipeline) requirements for proper component identification and CPE (Common Platform Enumeration) tracking.

## Test plan

- [ ] Verify the Dockerfile.rhtap syntax is valid
- [ ] Confirm the labels are correctly applied when building the container image

🤖 Generated with [Claude Code](https://claude.com/claude-code)