### PR TITLE
Update Dockerfile.rhtap labels with correct name and cpe values

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -11,7 +11,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
       url="https://github.com/stolostron/cluster-proxy-addon" \
-    name="cluster-proxy-addon" \
+    name="multicluster-engine/cluster-proxy-addon-rhel9" \
+    cpe="cpe:/a:redhat:multicluster_engine:2.10::el9" \
     com.redhat.component="cluster-proxy-addon" \
     description="Cluster Proxy Addon allows users to access the managed clusters from a hub cluster" \
     io.k8s.description="Cluster Proxy Addon allows users to access the managed clusters from a hub cluster" \


### PR DESCRIPTION
## Summary
- Update the `name` label in Dockerfile.rhtap to `multicluster-engine/cluster-proxy-addon-rhel9` to match the konflux component_name configuration
- Add `cpe` label with value `cpe:/a:redhat:multicluster_engine:2.10::el9` for proper CPE identification

## Motivation
The Dockerfile.rhtap labels need to be consistent with the konflux configuration:
- `name` should match the component_name: `multicluster-engine/cluster-proxy-addon-rhel9`
- `cpe` label should follow the format `cpe:/a:redhat:${group}:${version}::el9` where:
  - `${group}` = `multicluster_engine` (for mce bundle)
  - `${version}` = `2.10` (from backplane-2.10 branch)

## Test plan
- [ ] Verify the Dockerfile.rhtap builds correctly
- [ ] Verify the image labels are correctly applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)