### PR TITLE
Update Dockerfile.rhtap labels with component name and CPE

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -11,7 +11,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
       url="https://github.com/stolostron/cluster-proxy-addon" \
-    name="cluster-proxy-addon" \
+    name="multicluster-engine/cluster-proxy-addon-rhel9" \
+    cpe="cpe:/a:redhat:multicluster_engine:2.11::el9" \
     com.redhat.component="cluster-proxy-addon" \
     description="Cluster Proxy Addon allows users to access the managed clusters from a hub cluster" \
     io.k8s.description="Cluster Proxy Addon allows users to access the managed clusters from a hub cluster" \


### PR DESCRIPTION
## Summary

- Update the `name` label to use the correct component_name format (`multicluster-engine/cluster-proxy-addon-rhel9`)
- Add the `cpe` label (`cpe:/a:redhat:multicluster_engine:2.11::el9`) for Red Hat product identification

## Reasoning

This change aligns the Dockerfile.rhtap labels with the standardized component naming conventions:
- The `name` label now matches the component_name from the product configuration
- The `cpe` label provides Common Platform Enumeration identifier for Red Hat Multicluster Engine 2.11 on RHEL 9

## Test plan

- [ ] Verify the Dockerfile.rhtap builds successfully
- [ ] Verify the resulting image has the correct labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)