### PR TITLE
chore: upgrade Go to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.24-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
 
 WORKDIR /go/src/github.com/stolostron/cluster-proxy-addon
 

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
 
 WORKDIR /go/src/github.com/stolostron/cluster-proxy-addon
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/cluster-proxy-addon
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/onsi/ginkgo/v2 v2.17.1


### PR DESCRIPTION
## Summary
- Upgrade Go from 1.24 to 1.25
- Update Dockerfile builder images
- Update go.mod version

## Related issue(s)
Following the same pattern as #564

🤖 Generated with [Claude Code](https://claude.ai/code)