### PR TITLE
Update IMAGE_CLUSTER_PROXY to use backplane-2.8 tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build
 
 HELM?=_output/linux-amd64/helm
 
-IMAGE_CLUSTER_PROXY?=quay.io/stolostron/cluster-proxy:main
+IMAGE_CLUSTER_PROXY?=quay.io/stolostron/cluster-proxy:backplane-2.8
 IMAGE_PULL_POLICY=Always
 IMAGE_TAG?=latest
 


### PR DESCRIPTION
## Summary
- Update the default `IMAGE_CLUSTER_PROXY` variable in Makefile from `quay.io/stolostron/cluster-proxy:main` to `quay.io/stolostron/cluster-proxy:backplane-2.8`

## Motivation
The `backplane-2.8` branch should use the corresponding `backplane-2.8` image tag for the cluster-proxy component to ensure version consistency across the release branch.

## Changes
- Modified `Makefile` line 6: Changed image tag from `main` to `backplane-2.8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)