### PR TITLE
Update IMAGE_CLUSTER_PROXY to use backplane-2.6 tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build
 
 HELM?=_output/linux-amd64/helm
 
-IMAGE_CLUSTER_PROXY?=quay.io/stolostron/cluster-proxy:main
+IMAGE_CLUSTER_PROXY?=quay.io/stolostron/cluster-proxy:backplane-2.7
 IMAGE_PULL_POLICY=Always
 IMAGE_TAG?=latest
 


### PR DESCRIPTION
## Summary
- Update `IMAGE_CLUSTER_PROXY` from `quay.io/stolostron/cluster-proxy:main` to `quay.io/stolostron/cluster-proxy:backplane-2.6`
- Aligns the cluster-proxy image tag with the branch version for consistency

## Changes
This PR modifies the `Makefile` to use the `backplane-2.6` tag instead of `main` for the cluster-proxy image. This ensures that the backplane-2.6 branch uses the corresponding image version rather than the main branch image.

## Test Plan
- Verified the Makefile syntax is correct
- The change is a simple string substitution in the image tag