### PR TITLE
Update cluster-proxy image tag to backplane-2.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build
 
 HELM?=_output/linux-amd64/helm
 
-IMAGE_CLUSTER_PROXY?=quay.io/stolostron/cluster-proxy:main
+IMAGE_CLUSTER_PROXY?=quay.io/stolostron/cluster-proxy:backplane-2.7
 IMAGE_PULL_POLICY=Always
 IMAGE_TAG?=latest
 


### PR DESCRIPTION
## Summary
- Update `IMAGE_CLUSTER_PROXY` in Makefile from `main` to `backplane-2.7`
- Aligns the cluster-proxy image tag with the target branch version

## Changes
Changed `IMAGE_CLUSTER_PROXY?=quay.io/stolostron/cluster-proxy:main` to `IMAGE_CLUSTER_PROXY?=quay.io/stolostron/cluster-proxy:backplane-2.7`

## Motivation
For the `backplane-2.7` release branch, the cluster-proxy image should reference the corresponding `backplane-2.7` image tag instead of `main` to ensure version consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)