### PR TITLE
Update IMAGE_CLUSTER_PROXY to use backplane-2.10 tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build
 
 HELM?=_output/linux-amd64/helm
 
-IMAGE_CLUSTER_PROXY?=quay.io/stolostron/cluster-proxy:main
+IMAGE_CLUSTER_PROXY?=quay.io/stolostron/cluster-proxy:backplane-2.10
 IMAGE_PULL_POLICY=Always
 IMAGE_TAG?=latest
 


### PR DESCRIPTION
## Summary
- Update the default `IMAGE_CLUSTER_PROXY` tag from `main` to `backplane-2.10` in the Makefile
- This ensures the cluster-proxy image version aligns with the branch version for consistent versioning

## Changes
- Changed `IMAGE_CLUSTER_PROXY?=quay.io/stolostron/cluster-proxy:main` to `IMAGE_CLUSTER_PROXY?=quay.io/stolostron/cluster-proxy:backplane-2.10`

## Test plan
- [ ] Verify that the Makefile correctly references the `backplane-2.10` image tag
- [ ] Ensure e2e tests use the correct cluster-proxy image version

🤖 Generated with [Claude Code](https://claude.ai/claude-code)