### PR TITLE
Update pipelineRef pathInRepo to pipelines/common.yaml

### DIFF
--- a/.tekton/cluster-proxy-addon-mce-26-pull-request.yaml
+++ b/.tekton/cluster-proxy-addon-mce-26-pull-request.yaml
@@ -44,7 +44,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common_mce_2.6.yaml
+        value: pipelines/common.yaml
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-26

--- a/.tekton/cluster-proxy-addon-mce-26-push.yaml
+++ b/.tekton/cluster-proxy-addon-mce-26-push.yaml
@@ -47,7 +47,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common_mce_2.6.yaml
+        value: pipelines/common.yaml
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-26


### PR DESCRIPTION
## Summary

- Update `.tekton/cluster-proxy-addon-mce-26-pull-request.yaml` pathInRepo from `pipelines/common_mce_2.6.yaml` to `pipelines/common.yaml`
- Update `.tekton/cluster-proxy-addon-mce-26-push.yaml` pathInRepo from `pipelines/common_mce_2.6.yaml` to `pipelines/common.yaml`

This change unifies all branches to use the common pipeline file (`pipelines/common.yaml`) instead of branch-specific pipeline files.

## Test plan

- [ ] Verify Tekton pipeline triggers correctly on pull request events
- [ ] Verify Tekton pipeline triggers correctly on push events

🤖 Generated with [Claude Code](https://claude.com/claude-code)