### PR TITLE
Update Tekton pipeline pathInRepo to use common.yaml

### DIFF
--- a/.tekton/cluster-proxy-addon-mce-28-pull-request.yaml
+++ b/.tekton/cluster-proxy-addon-mce-28-pull-request.yaml
@@ -46,7 +46,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common_mce_2.8.yaml
+        value: pipelines/common.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-28
   workspaces:

--- a/.tekton/cluster-proxy-addon-mce-28-push.yaml
+++ b/.tekton/cluster-proxy-addon-mce-28-push.yaml
@@ -47,7 +47,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common_mce_2.8.yaml
+        value: pipelines/common.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-28
   workspaces:


### PR DESCRIPTION
## Summary
- Updated `.tekton/cluster-proxy-addon-mce-28-pull-request.yaml` and `.tekton/cluster-proxy-addon-mce-28-push.yaml` to use `pipelines/common.yaml` instead of branch-specific `pipelines/common_mce_2.8.yaml`
- This change unifies all branches to use a common pipeline file for consistency and maintainability

## Motivation
Previously, different branches used different pipeline YAML files (e.g., `pipelines/common_mce_2.8.yaml` for backplane-2.8). This change standardizes all branches to use `pipelines/common.yaml`, reducing the need to maintain multiple branch-specific pipeline configurations.

## Changes
| File | Change |
|------|--------|
| `.tekton/cluster-proxy-addon-mce-28-pull-request.yaml` | `pathInRepo: pipelines/common_mce_2.8.yaml` → `pathInRepo: pipelines/common.yaml` |
| `.tekton/cluster-proxy-addon-mce-28-push.yaml` | `pathInRepo: pipelines/common_mce_2.8.yaml` → `pathInRepo: pipelines/common.yaml` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)