### PR TITLE
Update Tekton pipeline reference to use common.yaml

### DIFF
--- a/.tekton/cluster-proxy-addon-mce-27-pull-request.yaml
+++ b/.tekton/cluster-proxy-addon-mce-27-pull-request.yaml
@@ -44,7 +44,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common_mce_2.7.yaml
+        value: pipelines/common.yaml
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-27

--- a/.tekton/cluster-proxy-addon-mce-27-push.yaml
+++ b/.tekton/cluster-proxy-addon-mce-27-push.yaml
@@ -47,7 +47,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common_mce_2.7.yaml
+        value: pipelines/common.yaml
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-27


### PR DESCRIPTION
## Summary

- Update `pipelineRef.pathInRepo` from `pipelines/common_mce_2.7.yaml` to `pipelines/common.yaml` in Tekton pipeline configurations
- This change unifies the pipeline reference across all branches for consistency

## Changes

The following files were updated:
- `.tekton/cluster-proxy-addon-mce-27-pull-request.yaml`
- `.tekton/cluster-proxy-addon-mce-27-push.yaml`

## Motivation

Previously, different branches used different pipeline YAML files (e.g., `pipelines/common_mce_2.7.yaml`). This PR standardizes all branches to use `pipelines/common.yaml` for better maintainability and consistency.

## Test plan

- [ ] Verify that the Tekton pipeline runs successfully with the updated reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)