### PR TITLE
chore: unify tekton pipeline path to pipelines/common.yaml

### DIFF
--- a/.tekton/cluster-proxy-addon-mce-29-pull-request.yaml
+++ b/.tekton/cluster-proxy-addon-mce-29-pull-request.yaml
@@ -44,7 +44,7 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/common_mce_2.9.yaml
+      value: pipelines/common.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-29
   workspaces:

--- a/.tekton/cluster-proxy-addon-mce-29-push.yaml
+++ b/.tekton/cluster-proxy-addon-mce-29-push.yaml
@@ -47,7 +47,7 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/common_mce_2.9.yaml
+      value: pipelines/common.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-29
   workspaces:


### PR DESCRIPTION
## Summary
- Updated `pipelineRef.pathInRepo` from `pipelines/common_mce_2.9.yaml` to `pipelines/common.yaml` in `.tekton/cluster-proxy-addon-mce-29-pull-request.yaml`
- Updated `pipelineRef.pathInRepo` from `pipelines/common_mce_2.9.yaml` to `pipelines/common.yaml` in `.tekton/cluster-proxy-addon-mce-29-push.yaml`

## Motivation
Previously, different branches used different pipeline YAML files. This change unifies all branches to use the common `pipelines/common.yaml` pipeline configuration.

## Test plan
- [ ] Verify that pull request pipeline runs successfully with the new path
- [ ] Verify that push pipeline runs successfully with the new path

🤖 Generated with [Claude Code](https://claude.ai/code)