### PR TITLE
chore: unify tekton pipeline reference to common.yaml

### DIFF
--- a/.tekton/cluster-proxy-addon-mce-210-pull-request.yaml
+++ b/.tekton/cluster-proxy-addon-mce-210-pull-request.yaml
@@ -44,7 +44,7 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/common_mce_2.10.yaml
+      value: pipelines/common.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-210
   workspaces:

--- a/.tekton/cluster-proxy-addon-mce-210-push.yaml
+++ b/.tekton/cluster-proxy-addon-mce-210-push.yaml
@@ -47,7 +47,7 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/common_mce_2.10.yaml
+      value: pipelines/common.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-cluster-proxy-addon-mce-210
   workspaces:


### PR DESCRIPTION
## Summary
- Update `pathInRepo` in `.tekton/cluster-proxy-addon-mce-210-pull-request.yaml` from `pipelines/common_mce_2.10.yaml` to `pipelines/common.yaml`
- Update `pathInRepo` in `.tekton/cluster-proxy-addon-mce-210-push.yaml` from `pipelines/common_mce_2.10.yaml` to `pipelines/common.yaml`

This change unifies the Tekton pipeline reference across different branches to use the common pipeline configuration file (`pipelines/common.yaml`) instead of branch-specific pipeline files.

## Test plan
- [ ] Verify the PR pipeline runs successfully
- [ ] Verify the push pipeline runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)