### PR TITLE
WIP: Add startup log message

### DIFF
--- a/cmd/cluster-proxy/main.go
+++ b/cmd/cluster-proxy/main.go
@@ -24,6 +24,7 @@ func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	klog.InitFlags(nil)
+	klog.Info("Starting cluster-proxy addon")
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 


### PR DESCRIPTION
## Description

This PR adds a startup log message to the cluster-proxy addon main function.

**Changes:**
- Added `klog.Info("Starting cluster-proxy addon")` to `cmd/cluster-proxy/main.go`

This is a test change to trigger CI workflows.

## Testing

N/A - This is a simple log addition to trigger CI.

/hold