### PR TITLE
WIP: chore: add startup log for version info

### DIFF
--- a/cmd/cluster-proxy/main.go
+++ b/cmd/cluster-proxy/main.go
@@ -24,6 +24,7 @@ func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	klog.InitFlags(nil)
+	klog.Infof("Starting cluster-proxy-addon, version: %s", version.Get().String())
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 


### PR DESCRIPTION
## Summary
- Add a startup log statement that displays the cluster-proxy-addon version
- This change is intended to trigger CI tests

## Test Plan
- [ ] CI tests should be triggered
- [ ] No functional changes expected

/hold

🤖 Generated with [Claude Code](https://claude.com/claude-code)