### PR TITLE
Add hubKubeConfig parameter to NewConfigChecker call

### DIFF
--- a/pkg/serviceproxy/service_proxy.go
+++ b/pkg/serviceproxy/service_proxy.go
@@ -84,7 +84,7 @@ func (s *serviceProxy) Run(ctx context.Context) error {
 	var err error
 	customChecks := []healthz.Checker{}
 
-	cc, err := addonutils.NewConfigChecker("cert", s.cert, s.key, rootCAFile)
+	cc, err := addonutils.NewConfigChecker("cert", s.cert, s.key, rootCAFile, s.hubKubeConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

This PR adds the `hubKubeConfig` parameter to the `NewConfigChecker` function call in `service_proxy.go`.

## Changes

- Updated the `NewConfigChecker` call in `pkg/serviceproxy/service_proxy.go` to include `s.hubKubeConfig` as the fifth parameter
- This ensures the config checker is aware of the hub kubeconfig file path for proper validation

## Reasoning

The `NewConfigChecker` function likely needs access to the hub kubeconfig to perform comprehensive configuration checks. By passing `s.hubKubeConfig` (which is already available as a field in the `serviceProxy` struct), we enable more thorough validation of the service proxy configuration.