### PR TITLE
Add hubKubeConfig parameter to NewConfigChecker call

### DIFF
--- a/pkg/serviceproxy/service_proxy.go
+++ b/pkg/serviceproxy/service_proxy.go
@@ -84,7 +84,7 @@ func (s *serviceProxy) Run(ctx context.Context) error {
 	var err error
 	customChecks := []healthz.Checker{}
 
-	cc, err := addonutils.NewConfigChecker("cert", s.cert, s.key, rootCAFile)
+	cc, err := addonutils.NewConfigChecker("cert", s.cert, s.key, rootCAFile, s.hubKubeConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

This PR updates the `NewConfigChecker` call in `service_proxy.go` to include the `hubKubeConfig` parameter.

## Changes

- Modified `pkg/serviceproxy/service_proxy.go` to add `s.hubKubeConfig` as an additional parameter to the `addonutils.NewConfigChecker` function call
- This change ensures the config checker has access to the hub kubeconfig for proper validation

## Motivation

The `NewConfigChecker` function signature was updated to accept an additional `hubKubeConfig` parameter, and this PR updates the call site to match the new signature.

Signed-off-by: xuezhaojun <xuezhaojun@gmail.com>