### PR TITLE
Add envtest setup using sdk-go ensure-envtest.sh [backplane-2.7]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,18 @@ PERMANENT_TMP ?= _output
 GO_TEST_PACKAGES :=./pkg/...
 KUBECTL ?= kubectl
 
+# envtest setup using sdk-go ensure-envtest.sh
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
+
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
+test: envtest-setup
+	go test $(GO_TEST_PACKAGES) -coverprofile coverage.out
+.PHONY: test
+
 CLUSTER_PROXY_ADDON_IMAGE?=${IMAGE_REGISTRY}/${IMAGE}:${IMAGE_TAG}
 
 build-all: build build-anp


### PR DESCRIPTION
## Summary

- Add `envtest-setup` Makefile target using the centralized `ensure-envtest.sh` script from [open-cluster-management-io/sdk-go](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/envtest/README-envtest.md)
- Add `test` Makefile target that depends on `envtest-setup` and runs unit tests with coverage output
- The script auto-detects Kubernetes version and setup-envtest branch from `go.mod`, with fallback logic for unavailable versions

## Changes

The Makefile now includes:
- `ENSURE_ENVTEST_SCRIPT` variable pointing to the sdk-go `ensure-envtest.sh` script
- `envtest-setup` target that downloads and runs the script to set up `KUBEBUILDER_ASSETS`
- `test` target that runs `go test $(GO_TEST_PACKAGES) -coverprofile coverage.out` after envtest setup

This replaces the need for any legacy `setup-envtest` install scripts or hardcoded kubebuilder binary paths with a zero-configuration, auto-detecting approach.

## Test plan

- [ ] Verify `make envtest-setup` downloads envtest binaries and sets `KUBEBUILDER_ASSETS`
- [ ] Verify `make test` runs unit tests successfully with coverage output
- [ ] Verify `_output/tools/bin` is used for binary caching (already in `.gitignore` via `_output/`)