### PR TITLE
Adopt sdk-go envtest setup for unit tests [backplane-2.6]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,17 @@ ANP_SRC_CODE ?= dependencymagnet/${ANP_NAME}/${ANP_VERSION}.tar.gz
 GO_TEST_PACKAGES :=./pkg/...
 KUBECTL ?= kubectl
 
+# envtest setup using sdk-go ensure-envtest.sh
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
+
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
+# Add envtest-setup as a prerequisite for test-unit (recipe from build-machinery-go)
+test-unit: envtest-setup
+
 CLUSTER_PROXY_ADDON_IMAGE?=${IMAGE_REGISTRY}/${IMAGE}:${IMAGE_TAG}
 
 # This will call a macro called "build-image" which will generate image specific targets based on the parameters:


### PR DESCRIPTION
## Summary

- Add `envtest-setup` Makefile target using the standardized `ensure-envtest.sh` script from [open-cluster-management-io/sdk-go](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/envtest/README-envtest.md)
- Wire `envtest-setup` as a prerequisite for `test-unit`, so envtest binaries (kube-apiserver, etcd, kubectl) are automatically provisioned before running unit tests
- The script auto-detects the K8s version from `go.mod` (`k8s.io/api`) and the `setup-envtest` branch from `controller-runtime`, with intelligent fallback resolution

## Motivation

This adopts the centralized envtest setup approach recommended by sdk-go, replacing any ad-hoc or implicit envtest configuration. Benefits include:

- **Zero setup overhead** — `envtest-setup` as a prerequisite handles everything automatically
- **Automatic version synchronization** — dependency updates in `go.mod` trigger correct binary selection
- **Intelligent fallback** — when exact K8s version binaries are unavailable, falls back to minor version wildcard then latest
- **No vendoring required** — the script is fetched at build time from sdk-go `main` branch

## Changes

- `Makefile`: Added `ENSURE_ENVTEST_SCRIPT` variable, `envtest-setup` target, and `test-unit: envtest-setup` prerequisite

## Test plan

- [ ] Verify `make envtest-setup` downloads envtest binaries and exports `KUBEBUILDER_ASSETS`
- [ ] Verify `make test-unit` triggers `envtest-setup` before running tests
- [ ] Verify existing unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)