### PR TITLE
Update envtest setup to use sdk-go shared script [backplane-2.8]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ PERMANENT_TMP ?= _output
 GO_TEST_PACKAGES :=./pkg/...
 KUBECTL ?= kubectl
 
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
+
 CLUSTER_PROXY_ADDON_IMAGE?=${IMAGE_REGISTRY}/${IMAGE}:${IMAGE_TAG}
 
 build-all: build build-anp
@@ -40,6 +42,15 @@ build-all: build build-anp
 build:
 	go build -o cluster-proxy ./cmd/cluster-proxy/main.go
 .PHONY: build
+
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
+test: envtest-setup
+	go test $(GO_TEST_PACKAGES) -coverprofile cover.out
+.PHONY: test
 
 build-anp:
 	mkdir -p $(PERMANENT_TMP)


### PR DESCRIPTION
## Summary

- Add `envtest-setup` Makefile target using the centralized `ensure-envtest.sh` script from [open-cluster-management-io/sdk-go](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/envtest/README-envtest.md)
- Add `test` Makefile target that depends on `envtest-setup` and runs unit tests (`./pkg/...`) with coverage output
- The script automatically detects K8s and controller-runtime versions from `go.mod`, installs `setup-envtest`, and downloads the appropriate envtest binaries

## Changes

The `envtest-setup` target:
- Fetches and executes the shared `ensure-envtest.sh` script from sdk-go
- Automatically resolves the correct envtest binary versions from `go.mod`
- Exports `KUBEBUILDER_ASSETS` for downstream test targets

The `test` target:
- Depends on `envtest-setup` to ensure kubebuilder binaries are available
- Runs `go test $(GO_TEST_PACKAGES) -coverprofile cover.out` (where `GO_TEST_PACKAGES` is already defined as `./pkg/...`)

## Notes

- No legacy envtest setup existed in this repo to remove
- No Go 1.25.x `go clean -cache` workaround was present — not added per task instructions
- Coverage output uses `cover.out` in the current directory — no `mkdir -p` required
- `_output/` is already in `.gitignore` for envtest binary caching

## Test plan

- [ ] Verify `make envtest-setup` successfully downloads envtest binaries
- [ ] Verify `make test` runs unit tests with envtest environment
- [ ] Verify existing `make build` and `make test-e2e` targets are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)