### PR TITLE
Add envtest setup using sdk-go ensure-envtest script [backplane-2.9]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ ANP_VERSION ?= 0.1.6.patch-03
 ANP_SRC_CODE ?= dependencymagnet/${ANP_NAME}/${ANP_VERSION}.tar.gz
 PERMANENT_TMP ?= _output
 
+# envtest setup
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
+
 # Add packages to do unit test
 GO_TEST_PACKAGES :=./pkg/...
 KUBECTL ?= kubectl
@@ -50,6 +53,15 @@ build-anp:
 	mv $(PERMANENT_TMP)/$(ANP_NAME)/proxy-agent ./
 	mv $(PERMANENT_TMP)/$(ANP_NAME)/proxy-server ./
 .PHONY: build-anp
+
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
+.PHONY: test-unit
+test-unit: envtest-setup
+	go test $(GO_TEST_PACKAGES) -coverprofile cover.out
 
 # e2e
 build-e2e:


### PR DESCRIPTION
## Summary

- Add `envtest-setup` Makefile target that uses the centralized [`ensure-envtest.sh`](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/envtest/ensure-envtest.sh) script from `open-cluster-management-io/sdk-go`
- Add `test-unit` Makefile target that depends on `envtest-setup` and runs unit tests with coverage output
- The `ENSURE_ENVTEST_SCRIPT` variable and `envtest-setup` target auto-detect Kubernetes and controller-runtime versions from `go.mod`, download the appropriate envtest binaries, and export `KUBEBUILDER_ASSETS`

## Changes

### Makefile
- Added `ENSURE_ENVTEST_SCRIPT` variable pointing to the sdk-go hosted script
- Added `envtest-setup` target that downloads and configures envtest binaries
- Added `test-unit` target that runs `go test $(GO_TEST_PACKAGES) -coverprofile cover.out` with envtest configured

## Notes
- This repo had no previous envtest setup, so this is a net-new addition
- No Go 1.25.x `go clean -cache` workaround was present, so none was added
- The `-coverprofile` output path (`cover.out`) is a simple filename with no subdirectories, so no `mkdir -p` is needed

## Test plan
- [ ] Verify `make envtest-setup` downloads envtest binaries and exports `KUBEBUILDER_ASSETS`
- [ ] Verify `make test-unit` runs unit tests successfully with envtest configured
- [ ] Verify existing targets (`build`, `build-e2e`, `test-e2e`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)