### PR TITLE
Add envtest setup using sdk-go ensure-envtest.sh [backplane-2.10]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ PERMANENT_TMP ?= _output
 GO_TEST_PACKAGES :=./pkg/...
 KUBECTL ?= kubectl
 
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
+
 CLUSTER_PROXY_ADDON_IMAGE?=${IMAGE_REGISTRY}/${IMAGE}:${IMAGE_TAG}
 
 build-all: build build-anp
@@ -50,6 +52,15 @@ build-anp:
 	mv $(PERMANENT_TMP)/$(ANP_NAME)/proxy-agent ./
 	mv $(PERMANENT_TMP)/$(ANP_NAME)/proxy-server ./
 .PHONY: build-anp
+
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
+.PHONY: test-unit
+test-unit: envtest-setup
+	go test $(GO_TEST_PACKAGES) -coverprofile cover.out
 
 # e2e
 build-e2e:


### PR DESCRIPTION
## Summary

- Add `envtest-setup` Makefile target that uses the centralized `ensure-envtest.sh` script from [open-cluster-management-io/sdk-go](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/envtest/README-envtest.md) to automatically download and configure kubebuilder envtest binaries based on `go.mod` dependency versions
- Add `test-unit` Makefile target depending on `envtest-setup` that runs unit tests in `./pkg/...` with coverage output
- The `ensure-envtest.sh` script provides zero-configuration envtest setup with automatic version detection from `go.mod`, version fallback resolution, and CI caching support

## Changes

**Makefile:**
- Added `ENSURE_ENVTEST_SCRIPT` variable pointing to the sdk-go `ensure-envtest.sh` script
- Added `envtest-setup` target that downloads envtest binaries and sets `KUBEBUILDER_ASSETS`
- Added `test-unit` target that depends on `envtest-setup` and runs `go test $(GO_TEST_PACKAGES) -coverprofile cover.out`

## Notes

- No legacy envtest setup existed in this repo, so this is a fresh addition
- Go 1.25.x build cache workaround (`go clean -cache`) was not present in this repo and was not added per task requirements
- Coverage output path (`cover.out`) is in the current directory, so no `mkdir -p` is needed

## Test plan

- [ ] Verify `make envtest-setup` downloads and configures envtest binaries correctly
- [ ] Verify `make test-unit` runs unit tests with envtest setup and generates `cover.out`

🤖 Generated with [Claude Code](https://claude.com/claude-code)