### PR TITLE
fix: [mce-29] cluster-proxy-addon-mce-29 - Konflux compliance failure

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -13,6 +13,7 @@ LABEL \
     name="multicluster-engine/cluster-proxy-addon-rhel9" \
     cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
     com.redhat.component="cluster-proxy-addon" \
+    url="https://github.com/stolostron/cluster-proxy-addon" \
     description="Cluster Proxy Addon allows users to access the managed clusters from a hub cluster" \
     io.k8s.description="Cluster Proxy Addon allows users to access the managed clusters from a hub cluster" \
     summary="A hub cluster proxy addon" \


### PR DESCRIPTION
## Bug
https://redhat.atlassian.net/browse/ACM-31519

## Root Cause
The Dockerfile.rhtap on the backplane-2.9 branch is missing the `url` label, which is required by Konflux Enterprise Contract (EC) policies for source code traceability. This label was added to newer branches but was not backported to 2.9.

## Fix
Add `url="https://github.com/stolostron/cluster-proxy-addon"` to the LABEL block in Dockerfile.rhtap on the backplane-2.9 branch.

## Auto-generated
This draft PR was automatically generated by server-foundation-agent based on bug triage analysis.
**Human review is required before merging.**

Co-Authored-By: server-foundation-agent <noreply@redhat.com>
