### PR TITLE
Add TokenReview result caching to service-proxy

### DIFF
--- a/pkg/serviceproxy/service_proxy.go
+++ b/pkg/serviceproxy/service_proxy.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stolostron/cluster-proxy-addon/pkg/constant"
+	"github.com/stolostron/cluster-proxy-addon/pkg/serviceproxy/tokenreviewcache"
 	"github.com/stolostron/cluster-proxy-addon/pkg/utils"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,6 +42,12 @@ func NewServiceProxyCommand() *cobra.Command {
 	return cmd
 }
 
+const (
+	// defaultTokenReviewCacheTTL is the default TTL for cached TokenReview results.
+	// Cached entries expire after this duration, forcing a fresh TokenReview API call.
+	defaultTokenReviewCacheTTL = 5 * time.Minute
+)
+
 type serviceProxy struct {
 	cert, key    string
 	ocpserviceCA string
@@ -51,13 +58,20 @@ type serviceProxy struct {
 	tLSHandshakeTimeout   time.Duration
 	expectContinueTimeout time.Duration
 
+	tokenReviewCacheTTL time.Duration
+
 	hubKubeConfig            string
 	hubKubeClient            kubernetes.Interface
 	managedClusterKubeClient kubernetes.Interface
+
+	managedClusterTokenCache *tokenreviewcache.Cache
+	hubTokenCache            *tokenreviewcache.Cache
 }
 
 func newServiceProxy() *serviceProxy {
-	return &serviceProxy{}
+	return &serviceProxy{
+		tokenReviewCacheTTL: defaultTokenReviewCacheTTL,
+	}
 }
 
 func (s *serviceProxy) AddFlags(cmd *cobra.Command) {
@@ -75,6 +89,9 @@ func (s *serviceProxy) AddFlags(cmd *cobra.Command) {
 	flags.DurationVar(&s.idleConnTimeout, "idle-conn-timeout", 90*time.Second, "The maximum amount of time an idle (keep-alive) connection will remain idle before closing itself.")
 	flags.DurationVar(&s.tLSHandshakeTimeout, "tls-handshake-timeout", 10*time.Second, "The maximum amount of time waiting to wait for a TLS handshake.")
 	flags.DurationVar(&s.expectContinueTimeout, "expect-continue-timeout", 1*time.Second, "The amount of time to wait for a server's first response headers after fully writing the request headers if the request has an \"Expect: 100-continue\" header.")
+
+	// token review cache flags
+	flags.DurationVar(&s.tokenReviewCacheTTL, "token-review-cache-ttl", defaultTokenReviewCacheTTL, "TTL for cached TokenReview results. Set to 0 to disable caching.")
 }
 
 func (s *serviceProxy) Run(ctx context.Context) error {
@@ -142,6 +159,15 @@ func (s *serviceProxy) Run(ctx context.Context) error {
 	s.hubKubeClient, err = kubernetes.NewForConfig(hubConfig)
 	if err != nil {
 		return err
+	}
+
+	// initialize token review caches
+	if s.tokenReviewCacheTTL > 0 {
+		s.managedClusterTokenCache = tokenreviewcache.New(s.tokenReviewCacheTTL)
+		s.hubTokenCache = tokenreviewcache.New(s.tokenReviewCacheTTL)
+		klog.Infof("TokenReview cache enabled with TTL %v", s.tokenReviewCacheTTL)
+	} else {
+		klog.Infof("TokenReview cache disabled")
 	}
 
 	go func() {
@@ -219,6 +245,14 @@ func (s *serviceProxy) validate() error {
 }
 
 func (s *serviceProxy) hubUserAuthenticatedAndInfo(token string) (bool, *authenticationv1.UserInfo, error) {
+	// check cache first
+	if s.hubTokenCache != nil {
+		if auth, user, found := s.hubTokenCache.Get(token); found {
+			klog.V(4).Info("hub TokenReview cache hit")
+			return auth, user, nil
+		}
+	}
+
 	tokenReview, err := s.hubKubeClient.AuthenticationV1().TokenReviews().Create(context.Background(), &authenticationv1.TokenReview{
 		Spec: authenticationv1.TokenReviewSpec{
 			Token: token,
@@ -229,12 +263,27 @@ func (s *serviceProxy) hubUserAuthenticatedAndInfo(token string) (bool, *authent
 	}
 
 	if !tokenReview.Status.Authenticated {
+		if s.hubTokenCache != nil {
+			s.hubTokenCache.Set(token, false, &authenticationv1.UserInfo{})
+		}
 		return false, nil, nil
+	}
+
+	if s.hubTokenCache != nil {
+		s.hubTokenCache.Set(token, true, &tokenReview.Status.User)
 	}
 	return true, &tokenReview.Status.User, nil
 }
 
 func (s *serviceProxy) managedClusterUserAuthenticatedAndInfo(token string) (bool, *authenticationv1.UserInfo, error) {
+	// check cache first
+	if s.managedClusterTokenCache != nil {
+		if auth, user, found := s.managedClusterTokenCache.Get(token); found {
+			klog.V(4).Info("managed cluster TokenReview cache hit")
+			return auth, user, nil
+		}
+	}
+
 	tokenReview, err := s.managedClusterKubeClient.AuthenticationV1().TokenReviews().Create(context.Background(), &authenticationv1.TokenReview{
 		Spec: authenticationv1.TokenReviewSpec{
 			Token: token,
@@ -245,7 +294,14 @@ func (s *serviceProxy) managedClusterUserAuthenticatedAndInfo(token string) (boo
 	}
 
 	if !tokenReview.Status.Authenticated {
+		if s.managedClusterTokenCache != nil {
+			s.managedClusterTokenCache.Set(token, false, &authenticationv1.UserInfo{})
+		}
 		return false, nil, nil
+	}
+
+	if s.managedClusterTokenCache != nil {
+		s.managedClusterTokenCache.Set(token, true, &tokenReview.Status.User)
 	}
 	return true, &tokenReview.Status.User, nil
 }

--- a/pkg/serviceproxy/tokenreviewcache/cache.go
+++ b/pkg/serviceproxy/tokenreviewcache/cache.go
@@ -1,0 +1,93 @@
+package tokenreviewcache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+	"time"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+)
+
+// entry holds a cached TokenReview result with an expiration time.
+type entry struct {
+	authenticated bool
+	user          *authenticationv1.UserInfo
+	expiresAt     time.Time
+}
+
+// Cache provides a thread-safe TTL cache for TokenReview results.
+// It uses a token hash as the key to avoid storing raw tokens in memory.
+type Cache struct {
+	mu      sync.RWMutex
+	entries map[string]*entry
+	ttl     time.Duration
+}
+
+// New creates a new TokenReview cache with the given TTL for cached entries.
+func New(ttl time.Duration) *Cache {
+	c := &Cache{
+		entries: make(map[string]*entry),
+		ttl:     ttl,
+	}
+	go c.startEviction()
+	return c
+}
+
+// Get looks up a cached TokenReview result by token.
+// Returns (authenticated, userInfo, found).
+func (c *Cache) Get(token string) (bool, *authenticationv1.UserInfo, bool) {
+	key := hashToken(token)
+
+	c.mu.RLock()
+	e, ok := c.entries[key]
+	c.mu.RUnlock()
+
+	if !ok || time.Now().After(e.expiresAt) {
+		return false, nil, false
+	}
+
+	return e.authenticated, e.user, true
+}
+
+// Set stores a TokenReview result in the cache.
+func (c *Cache) Set(token string, authenticated bool, user *authenticationv1.UserInfo) {
+	key := hashToken(token)
+
+	c.mu.Lock()
+	c.entries[key] = &entry{
+		authenticated: authenticated,
+		user:          user.DeepCopy(),
+		expiresAt:     time.Now().Add(c.ttl),
+	}
+	c.mu.Unlock()
+}
+
+// startEviction periodically removes expired entries to prevent memory leaks.
+func (c *Cache) startEviction() {
+	ticker := time.NewTicker(c.ttl)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		c.evict()
+	}
+}
+
+func (c *Cache) evict() {
+	now := time.Now()
+
+	c.mu.Lock()
+	for k, e := range c.entries {
+		if now.After(e.expiresAt) {
+			delete(c.entries, k)
+		}
+	}
+	c.mu.Unlock()
+}
+
+// hashToken returns a hex-encoded SHA-256 hash of the token.
+// We never store raw tokens in the cache.
+func hashToken(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(h[:])
+}

--- a/pkg/serviceproxy/tokenreviewcache/cache_test.go
+++ b/pkg/serviceproxy/tokenreviewcache/cache_test.go
@@ -1,0 +1,108 @@
+package tokenreviewcache
+
+import (
+	"testing"
+	"time"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+)
+
+func TestCacheHitAndMiss(t *testing.T) {
+	c := New(5 * time.Second)
+
+	user := &authenticationv1.UserInfo{
+		Username: "test-user",
+		Groups:   []string{"system:authenticated"},
+	}
+
+	// miss before set
+	_, _, found := c.Get("token-abc")
+	if found {
+		t.Fatal("expected cache miss for unseen token")
+	}
+
+	// set and hit
+	c.Set("token-abc", true, user)
+	auth, info, found := c.Get("token-abc")
+	if !found {
+		t.Fatal("expected cache hit")
+	}
+	if !auth {
+		t.Fatal("expected authenticated=true")
+	}
+	if info.Username != "test-user" {
+		t.Fatalf("expected username test-user, got %s", info.Username)
+	}
+}
+
+func TestCacheExpiration(t *testing.T) {
+	c := New(50 * time.Millisecond)
+
+	user := &authenticationv1.UserInfo{Username: "u"}
+	c.Set("tok", true, user)
+
+	// should hit immediately
+	_, _, found := c.Get("tok")
+	if !found {
+		t.Fatal("expected cache hit before expiry")
+	}
+
+	// wait for expiry
+	time.Sleep(100 * time.Millisecond)
+
+	_, _, found = c.Get("tok")
+	if found {
+		t.Fatal("expected cache miss after expiry")
+	}
+}
+
+func TestCacheUnauthenticated(t *testing.T) {
+	c := New(5 * time.Second)
+
+	c.Set("bad-token", false, &authenticationv1.UserInfo{})
+	auth, _, found := c.Get("bad-token")
+	if !found {
+		t.Fatal("expected cache hit for unauthenticated token")
+	}
+	if auth {
+		t.Fatal("expected authenticated=false for unauthenticated token")
+	}
+}
+
+func TestCacheDoesNotStoreRawToken(t *testing.T) {
+	c := New(5 * time.Second)
+
+	c.Set("secret-token", true, &authenticationv1.UserInfo{Username: "u"})
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	for key := range c.entries {
+		if key == "secret-token" {
+			t.Fatal("cache stored raw token as key — must store hash only")
+		}
+	}
+}
+
+func TestCacheDeepCopiesUserInfo(t *testing.T) {
+	c := New(5 * time.Second)
+
+	user := &authenticationv1.UserInfo{
+		Username: "original",
+		Groups:   []string{"g1"},
+	}
+
+	c.Set("tok", true, user)
+
+	// mutate the original
+	user.Username = "mutated"
+	user.Groups[0] = "mutated-group"
+
+	_, info, _ := c.Get("tok")
+	if info.Username != "original" {
+		t.Fatalf("expected cached username 'original', got '%s'", info.Username)
+	}
+	if info.Groups[0] != "g1" {
+		t.Fatalf("expected cached group 'g1', got '%s'", info.Groups[0])
+	}
+}


### PR DESCRIPTION
## Summary

- Add a TTL-based in-memory cache for TokenReview results in the service-proxy component
- Each request currently triggers 1-2 synchronous TokenReview API calls with no caching, causing significant latency under high concurrency (e.g., ArgoCD push model traffic via cluster-proxy after ACM 2.16 upgrade)
- Default TTL is 5 minutes, configurable via `--token-review-cache-ttl` flag (set to `0` to disable)

## Details

**Problem:** After upgrading to ACM 2.16, ArgoCD push model traffic is routed through cluster-proxy by default. The service-proxy performs a TokenReview against the managed cluster API server for every request, and if that fails, a second TokenReview against the hub. Under load, this creates excessive API server pressure and latency spikes (observed: ~1m35s for a simple healthz check).

**Solution:** Cache TokenReview results keyed by a SHA-256 hash of the token. Both authenticated and unauthenticated results are cached. Expired entries are automatically evicted.

**Security considerations:**
- Raw tokens are never stored in the cache — only their SHA-256 hash is used as key
- Cache entries are deep-copied to prevent mutation
- TTL ensures stale auth decisions are bounded (default 5 min)
- Cache can be disabled entirely via `--token-review-cache-ttl=0`

## Test plan

- [x] Unit tests for cache hit/miss, expiration, unauthenticated caching, hash-only storage, deep copy
- [ ] Integration test: verify cached TokenReview reduces API server calls under concurrent load
- [ ] E2E: deploy on a cluster with ArgoCD push model and measure latency improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)