### PR TITLE
[backplane-2.10] fix: pin clusteradm to v1.2.0 for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,14 @@ build-e2e:
 	go test -c ./test/e2e
 .PHONY: build-e2e
 
+CLUSTERADM_VERSION ?= v1.2.0
+OS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH ?= $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+
 deploy-ocm:
-	curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | INSTALL_DIR=$(PWD) bash
+	curl -L https://github.com/open-cluster-management-io/clusteradm/releases/download/$(CLUSTERADM_VERSION)/clusteradm_$(OS)_$(ARCH).tar.gz | tar xzf - -C $(PWD)
 	$(PWD)/clusteradm init --output-join-command-file join.sh --wait
-	echo " loopback --force-internal-endpoint-lookup" >> join.sh && sh join.sh
+	sh join.sh loopback --force-internal-endpoint-lookup
 	$(PWD)/clusteradm accept --clusters loopback --wait 30
 	$(KUBECTL) wait --for=condition=ManagedClusterConditionAvailable managedcluster/loopback
 .PHONY: deploy-ocm


### PR DESCRIPTION
Pin clusteradm version to v1.2.0 (which deploys OCM v1.2.0) to avoid the v1beta1 sentinel value bug in OCM v1.3.0 that causes e2e test failures with 'addon deployment config desired spec hash is empty'.

OCM v1.2.0 has v1beta1 APIs and conversion webhook, but uses v1alpha1 internally and does not have the sentinel value leak bug.